### PR TITLE
ignore empty commit set for sentry deployment

### DIFF
--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -71,7 +71,7 @@ create_sentry_release() {
     return
   fi
 
-  sentry-cli releases new --finalize --project "${PROJECT_NAME}" "${SENTRY_RELEASE}"
+  sentry-cli releases new --finalize --project --ignore-empty "${PROJECT_NAME}" "${SENTRY_RELEASE}"
   success "Created new Sentry release"
 
   sentry-cli releases set-commits --auto "${SENTRY_RELEASE}"

--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -71,10 +71,10 @@ create_sentry_release() {
     return
   fi
 
-  sentry-cli releases new --finalize --project --ignore-empty "${PROJECT_NAME}" "${SENTRY_RELEASE}"
+  sentry-cli releases new --finalize --project "${PROJECT_NAME}" "${SENTRY_RELEASE}"
   success "Created new Sentry release"
 
-  sentry-cli releases set-commits --auto "${SENTRY_RELEASE}"
+  sentry-cli releases set-commits --ignore-empty --auto "${SENTRY_RELEASE}"
   success "Associate commits with the release"
 }
 

--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -74,7 +74,7 @@ create_sentry_release() {
   sentry-cli releases new --finalize --project "${PROJECT_NAME}" "${SENTRY_RELEASE}"
   success "Created new Sentry release"
 
-  sentry-cli releases set-commits --ignore-empty --auto "${SENTRY_RELEASE}"
+  sentry-cli releases set-commits --ignore-empty --ignore-missing --auto "${SENTRY_RELEASE}"
   success "Associate commits with the release"
 }
 


### PR DESCRIPTION
When you (re)deploy an instance Sentry wil throw an error:

> Could not determine any commits to be associated with a repo-based integration. Proceeding to find commits from local git tree.
> error: No commits found. Change commits range, initial depth or use --ignore-empty to allow empty patch sets.
> 

This should prevent this error.